### PR TITLE
Second note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ A demo app that uses gstreamer with a SwiftUI interface to display a local RTSP 
 
 **Note**: Before building the app, change the RTSP address [here](https://github.com/borarak/GStreamerSwiftUIDemo/blob/9d257a84243bd4c9063f1909020eae028bf3a319/GStreamerSwiftUIDemo/GStreamerBackend.m#L163) to a valid one.
 
+**Note 2**: Before compiling to an actual device, make sure that you removed "arm64" from the Excluded Architecture in the Build Settings
 
 ![play](screenshot_2.png)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ A demo app that uses gstreamer with a SwiftUI interface to display a local RTSP 
 
 **Note**: Before building the app, change the RTSP address [here](https://github.com/borarak/GStreamerSwiftUIDemo/blob/9d257a84243bd4c9063f1909020eae028bf3a319/GStreamerSwiftUIDemo/GStreamerBackend.m#L163) to a valid one.
 
-**Note 2**: Before compiling to an actual device, make sure that you removed "arm64" from the Excluded Architecture in the Build Settings
+**Note 2**: Before compiling to an actual device, make sure that you removed "arm64" from the Excluded Architecture in the Build Settings.
 
 ![play](screenshot_2.png)


### PR DESCRIPTION
Second note added in the README. This informs users of a needed change in the Xcode settings, when compiling to an actual device, instead of a simulator.